### PR TITLE
implement boto class skipping airflow hook

### DIFF
--- a/cloud_providers.py
+++ b/cloud_providers.py
@@ -53,12 +53,13 @@ class AwsCloudProvider(CloudProvider):
             )
             s3Class = S3Hook(aws_conn_id=kwargs["conn_id"])
             s3Class.check_for_bucket(bucket_name=kwargs["bucket_name"])
+            s3Client = s3Class.get_conn()
+
             with open(kwargs["file_path"], "rb") as f:
-                s3Class._upload_file_obj(
-                    file_obj=f,
-                    key=kwargs["file_name"],
-                    bucket_name=kwargs["bucket_name"],
-                    replace=kwargs["replace"] or False,
+                s3Client.upload_fileobj(
+                    Fileobj=f,
+                    Key=kwargs["file_name"],
+                    Bucket=kwargs["bucket_name"],
                 )
             log.info("data sent to s3 bucket sucessfully")
             return True, kwargs["release_name"], self.provider, None


### PR DESCRIPTION
**Issue Description**
currently db cleanup plugin fails to archieve data to aws s3 bucket and fails with error log ```db export failed with exception replace``` 

**Issue Explanation**
After debugguing the code seems the code which calls the s3hook on airflow provider doesn't work anymore 

**Fix Added**
with the new implementation we are calling the boto hook directly to copy data back to s3 bucket