### PR TITLE
make gcp bucket file replace defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ You must have the astro CLI installed.
 
 ## Publishing new packages to GitHub
 
-1. Update the `__version__` variable in `dbcleanup_plugin.py`
+1. Update the `version` variable in `pyproject.toml`
 2. Run `python -m build`
 3. Upload the generated Wheel (`.whl`) and `.tar.gz` files generated in `dist/` to GitHub as a release

--- a/cloud_providers.py
+++ b/cloud_providers.py
@@ -58,7 +58,7 @@ class AwsCloudProvider(CloudProvider):
                     file_obj=f,
                     key=kwargs["file_name"],
                     bucket_name=kwargs["bucket_name"],
-                    replace=kwargs["replace"] or False,
+                    replace=True,
                 )
             log.info("data sent to s3 bucket sucessfully")
             return True, kwargs["release_name"], self.provider, None

--- a/dbcleanup_plugin.py
+++ b/dbcleanup_plugin.py
@@ -28,8 +28,6 @@ from typing import Callable, TypeVar, cast, Sequence
 
 T = TypeVar("T", bound=Callable)
 
-__version__ = "1.0.4"
-
 log = logging.getLogger(__name__)
 
 

--- a/dbcleanup_plugin.py
+++ b/dbcleanup_plugin.py
@@ -296,8 +296,7 @@ def export_cleaned_records(
         file_path=file_path,
         file_name=file_name,
         provider_secret_env_name=provider_secret_env_name,
-        release_name=release_name,
-        replace=True,
+        release_name=release_name
     )
 
     if not status:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["build", "setuptools>=61.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-dynamic = ["version"]
+version = "1.0.5"
 name = "astronomer-dbcleanup-plugin"
 description = "A DB cleanup plugin for Astronomer Airflow"
 readme = "README.md"


### PR DESCRIPTION
this change sets the aws airflow providers file replace option defaults to true in order to replace existing files 

related issue: https://github.com/astronomer/issues/issues/6700
related issue: https://github.com/astronomer/issues/issues/6565